### PR TITLE
Don't cache if ttl is 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ async function dnsResolve(host, ipv6) {
 
   const res = await resolve(host);
   const rec = res[Math.floor(Math.random() * res.length)];
-  cache.set(host, rec.address, rec.ttl * 1000);
+  if (rec.ttl > 0) {
+    cache.set(host, rec.address, rec.ttl * 1000);
+  }
   return rec.address;
 }
 module.exports = dnsResolve;


### PR DESCRIPTION
Sometimes a nameserver may return TTL = 0 and in this case LRU would cache it forever but instead we shouldn't cache it all.