### PR TITLE
Disable /etc/hosts file temporarily

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const dns = require('dns');
-const hostfile = require('@zeit/cached-hostfile');
 const retry = require('async-retry');
 const LRU = require('lru-cache');
 
@@ -13,17 +12,6 @@ const cache6 = LRU(lruOptions);
 
 function resolve4(host, resolver) {
   return new Promise((resolve, reject) => {
-    // Try to resolve from the hostfile
-    const localips = hostfile.resolve4(host);
-    if (localips) {
-      return resolve(localips.map(ip => {
-        return {
-          address: String(ip),
-          ttl: HOSTFILE_RESULT_TTL
-        };
-      }));
-    }
-
     resolver.resolve4(host, { ttl: true }, (err, res) => {
       if (err) return reject(err);
       resolve(res);
@@ -33,17 +21,6 @@ function resolve4(host, resolver) {
 
 function resolve6(host, resolver) {
   return new Promise((resolve, reject) => {
-    // Try to resolve from the hostfile
-    const localips = hostfile.resolve6(host);
-    if (localips) {
-      return resolve(localips.map(ip => {
-        return {
-          address: String(ip),
-          ttl: HOSTFILE_RESULT_TTL
-        };
-      }));
-    }
-
     resolver.resolve6(host, { ttl: true }, (err, res) => {
       if (err) return reject(err);
       resolve(res);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "main": "index.js",
   "author": "Olli Vanhoja",
   "dependencies": {
-    "@zeit/cached-hostfile": "^0.1.0",
     "async-retry": "1.1.3",
     "lru-cache": "4.1.1"
   },


### PR DESCRIPTION
The `hostile` libary is broken as it never closes the files it
opens and thus after some time we get:

```
EMFILE: too many open files, open '/etc/hosts'
```