### PR TITLE
Fix resolve for localhost

### DIFF
--- a/src/dns-resolve.ts
+++ b/src/dns-resolve.ts
@@ -29,6 +29,8 @@ class DNSError extends Error {
 
 setupCache();
 
+const localhostRegex = /(?:\.|^)localhost\.?$/;
+
 export default async function dnsResolve(host: string, options: Options = {}) {
   const {
     ipv6 = false,
@@ -37,6 +39,10 @@ export default async function dnsResolve(host: string, options: Options = {}) {
     retryOpts = { minTimeout: 10, retries: 3, factor: 5 },
     resolver = dns
   } = options;
+
+	if (localhostRegex.test(host)) {
+		return ipv6 ? '::1' : '127.0.0.1';
+	}
 
   const { cache, resolve } = ipv6
     ? { cache: cache6, resolve: resolve6 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,7 @@
 import { Resolver } from 'dns'
 import dnsResolve, { setupCache } from '../src/dns-resolve';
 
-const domains = ['s3.amazonaws.com', 'zeit.co'];
+const domains = ['s3.amazonaws.com', 'vercel.com'];
 
 beforeEach(setupCache);
 
@@ -47,6 +47,16 @@ test('concurrent resolves', async () => {
 }, 10000);
 
 test('Proper error on CNAME pointing to nowhere', async () => {
-  const p = dnsResolve('dns-cached-resolve-test.zeit.rocks');
-  await expect(p).rejects.toThrow('queryA ENOTFOUND dns-cached-resolve-test.zeit.rocks');
+  const p = dnsResolve('dns-cached-resolve-test.vercel.rocks');
+  await expect(p).rejects.toThrow('queryA ENOTFOUND dns-cached-resolve-test.vercel.rocks');
+}, 10000);
+
+test('Resolve localhost v4', async () => {
+  const ip = await dnsResolve('localhost');
+  await expect(ip).toEqual('127.0.0.1');
+}, 10000);
+
+test('Resolve localhost v6', async () => {
+  const ip = await dnsResolve('localhost', { ipv6: true });
+  await expect(ip).toEqual('::1');
 }, 10000);


### PR DESCRIPTION
This short circuits the resolve for `localhost` and defaults to `127.0.0.1` and `::1`. Right now it fails when it tries to resolve it because the resolve function will use a DNS Server to retrieve the result, but in the case of localhost, it'd actually need to lookup the `/etc/hosts` file.
